### PR TITLE
Undo/redo functionality

### DIFF
--- a/assets/app/scripts/core/canvas.js
+++ b/assets/app/scripts/core/canvas.js
@@ -285,8 +285,10 @@ class MathBoard {
 				const screenDeltaX = event.clientX - this.dragStart.x;
 				const screenDeltaY = event.clientY - this.dragStart.y;
 
-				const canvasDeltaX = screenDeltaX / this.canvasState.scale;
-				const canvasDeltaY = screenDeltaY / this.canvasState.scale;
+				// I have no idea why, but you need to square this.canvasState.scale, otherwise the dragging is too
+				//  fast when zoomed in and too slow when zoomed out. But this fixes it.
+				const canvasDeltaX = screenDeltaX / (this.canvasState.scale * this.canvasState.scale);
+				const canvasDeltaY = screenDeltaY / (this.canvasState.scale * this.canvasState.scale);
 
 				const snapToGrid = event.ctrlKey || event.metaKey;
 

--- a/assets/app/scripts/core/canvas.js
+++ b/assets/app/scripts/core/canvas.js
@@ -6,6 +6,7 @@ import { Navigation } from './navigation.js';
 import { MathFieldEditor } from '../math/mathfield-editor.js';
 import { TextGroup } from '../text/textgroup.js';
 import { MathGroup } from '../math/mathgroup.js';
+import { UndoManager } from './undo-manager.js';
 
 const MQ = window.MathQuill ? window.MathQuill.getInterface(2) : null;
 
@@ -42,6 +43,7 @@ class MathBoard {
 		};
 
 		this.fileManager = new FileManager(this);
+		this.undoManager = new UndoManager();
 		this.clipboard = new Clipboard(this);
 		this.initEventListeners();
 
@@ -95,6 +97,19 @@ class MathBoard {
 		if (this.isUserCurrentlyEditing()) return;
 
 		switch (e.key) {
+			case 'z':
+			case 'Z':
+				e.preventDefault();
+				if (e.shiftKey) {
+					this.undoManager.redo(this);
+				} else {
+					this.undoManager.undo(this);
+				}
+				break;
+			case 'y':
+				e.preventDefault();
+				this.undoManager.redo(this);
+				break;
 			case 'c':
 				e.preventDefault();
 				this.clipboard.copySelectedGroups();

--- a/assets/app/scripts/core/undo-manager.js
+++ b/assets/app/scripts/core/undo-manager.js
@@ -1,0 +1,116 @@
+/**
+ * UndoManager - Manages undo/redo history for the canvas board.
+ *
+ * Strategy: snapshot-based undo/redo.
+ * history: oldest → newest (current state is always the last entry).
+ * future:  states that were undone, oldest-undone first (redo restores from the end).
+ */
+
+class UndoManager {
+	/**
+	 * @param {number} maxHistory - Maximum number of snapshots to keep.
+	 */
+	constructor(maxHistory = 100) {
+		this.maxHistory = maxHistory;
+		this.history = [];
+		this.future = [];
+
+		/** True while we are in the middle of restoring a snapshot. */
+		this.isRestoring = false;
+	}
+
+	/**
+	 * Capture a snapshot of the current canvas state.
+	 * Called by FileWriter.saveState() *before* the cloud upload so that even
+	 * a failed save still gets an undo entry.
+	 *
+	 * @param {string} stateString - JSON string produced by FileWriter.
+	 */
+	pushSnapshot(stateString) {
+		if (this.isRestoring) return;
+
+		// A brand-new action invalidates the redo stack.
+		this.future = [];
+
+		// Avoid duplicate consecutive snapshots (e.g. rapid fire events).
+		if (this.history.length > 0 && this.history[this.history.length - 1] === stateString) {
+			return;
+		}
+
+		this.history.push(stateString);
+
+		if (this.history.length > this.maxHistory) {
+			this.history.shift();
+		}
+	}
+
+	/**
+	 * Undo: restore the previous snapshot.
+	 *
+	 * @param {import('./canvas.js').MathBoard} board
+	 * @returns {boolean} true if an undo was performed.
+	 */
+	undo(board) {
+		if (this.history.length < 2) return false;
+
+		// Move the current state onto the redo stack.
+		this.future.push(this.history.pop());
+
+		const previousState = this.history[this.history.length - 1];
+
+		this.isRestoring = true;
+		try {
+			// importData with shouldSave=false so we don't trigger another
+			// saveState → pushSnapshot cycle.
+			board.fileManager.importData(previousState, false);
+		} finally {
+			this.isRestoring = false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Redo: restore the next undone snapshot.
+	 *
+	 * @param {import('./canvas.js').MathBoard} board
+	 * @returns {boolean} true if a redo was performed.
+	 */
+	redo(board) {
+		if (this.future.length === 0) return false;
+
+		// Move the next future state back onto the history stack.
+		const nextState = this.future.pop();
+		this.history.push(nextState);
+
+		this.isRestoring = true;
+		try {
+			// importData with shouldSave=false so we don't trigger another
+			// saveState → pushSnapshot cycle.
+			board.fileManager.importData(nextState, false);
+		} finally {
+			this.isRestoring = false;
+		}
+
+		return true;
+	}
+
+	/** Returns true if there is anything to undo. */
+	canUndo() {
+		return this.history.length >= 2;
+	}
+
+	/** Returns true if there is anything to redo. */
+	canRedo() {
+		return this.future.length > 0;
+	}
+
+	/** Clear all history (e.g. when a new file is loaded). */
+	clear() {
+		this.history = [];
+		this.future = [];
+	}
+}
+
+export { UndoManager };
+

--- a/assets/app/scripts/file/filereader.js
+++ b/assets/app/scripts/file/filereader.js
@@ -97,6 +97,13 @@ class FileReader {
 			if (shouldSave) {
 				this.fileManager.fileWriter.saveState();
 			} else {
+				// When loading a file fresh (not an undo-restore), reset the undo
+				// history and seed it with this snapshot so the very first Ctrl+Z
+				// does nothing rather than restoring an empty board.
+				if (this.board.undoManager && !this.board.undoManager.isRestoring) {
+					this.board.undoManager.clear();
+					this.board.undoManager.pushSnapshot(jsonData);
+				}
 				EquivalenceUtils.updateEquivalenceState();
 			}
 		} catch (error) {

--- a/assets/app/scripts/file/filewriter.js
+++ b/assets/app/scripts/file/filewriter.js
@@ -97,6 +97,11 @@ class FileWriter {
 
 		const stateString = JSON.stringify(saveData);
 
+		// Push snapshot into the undo manager before any cloud I/O.
+		if (this.board.undoManager) {
+			this.board.undoManager.pushSnapshot(stateString);
+		}
+
 		if (!this.fileManager.fileId && this.saveButton) this.saveButton.setSyncing(true);
 
 		if (!this.fileManager.fileId) {

--- a/assets/app/scripts/math/mathfield-editor.js
+++ b/assets/app/scripts/math/mathfield-editor.js
@@ -1,5 +1,5 @@
-import { MathFieldUtils } from './mathfield-utils.js';
-import { MathFieldUIManager } from './mathfield-ui-manager.js';
+import {MathFieldUtils} from './mathfield-utils.js';
+import {MathFieldUIManager} from './mathfield-ui-manager.js';
 
 const MQ = window.MathQuill ? window.MathQuill.getInterface(2) : null;
 
@@ -9,6 +9,7 @@ class MathFieldEditor {
 		this.mathGroup = mathGroup;
 		this.mathField = null;
 		this.mathFieldElement = null;
+		this._saveTimeout = null;
 	}
 
 	createMathField() {
@@ -35,6 +36,7 @@ class MathFieldEditor {
 			handlers: {
 				edit: () => {
 					this.container.dataset.latex = this.mathField.latex().trim();
+					MathFieldEditor.scheduleSave(this.container, this.mathGroup.board);
 				}
 			}
 		};
@@ -57,7 +59,7 @@ class MathFieldEditor {
 		return this.mathFieldElement;
 	}
 
-	// existicng math field editing methods
+	// existing math field editing methods
 	static edit(container) {
 		const existingLatex = container.dataset.latex || '';
 
@@ -123,6 +125,8 @@ class MathFieldEditor {
 			handlers: {
 				edit: () => {
 					container.dataset.latex = mathField.latex().trim();
+					const board = container.closest('.math-group')?.mathGroup?.board;
+					MathFieldEditor.scheduleSave(container, board);
 				}
 			}
 		});
@@ -141,6 +145,24 @@ class MathFieldEditor {
 	static attachEditKeydownListener(mathFieldElement, container) {
 		mathFieldElement.addEventListener('keydown', (event) => {
 			const mathField = MQ(mathFieldElement);
+
+			if ((event.ctrlKey || event.metaKey) && (event.key === 'z' || event.key === 'Z')) {
+				event.preventDefault();
+				event.stopPropagation();
+				if (event.shiftKey) {
+					MathFieldEditor.triggerRedo(container);
+				} else {
+					MathFieldEditor.triggerUndo(container);
+				}
+				return;
+			}
+
+			if ((event.ctrlKey || event.metaKey) && event.key === 'y') {
+				event.preventDefault();
+				event.stopPropagation();
+				MathFieldEditor.triggerRedo(container);
+				return;
+			}
 
 			if (event.key === 'Backspace') {
 				MathFieldEditor.handleStaticBackspace(event, mathField, container);
@@ -248,10 +270,69 @@ class MathFieldEditor {
 
 		const group = container.parentElement;
 		if (group && group.mathGroup) {
+			// Cancel any pending debounced save — blur does a final immediate save.
+			MathFieldEditor.cancelScheduledSave(container);
 			group.mathGroup.board.fileManager.saveState();
 			MathFieldUIManager.processEquivalenceColors(container, hasText);
 		}
 	}
+
+	// ── Debounced save while typing ──────────────────────────────────────────
+
+	/**
+	 * Schedule a canvas saveState() 600ms after the last keystroke.
+	 * This means every distinct pause in typing creates an undo checkpoint.
+	 */
+	static scheduleSave(container, board) {
+		if (!board) return;
+		if (container._saveTimeout) clearTimeout(container._saveTimeout);
+		container._saveTimeout = setTimeout(() => {
+			container._saveTimeout = null;
+			board.fileManager.saveState();
+		}, 600);
+	}
+
+	static cancelScheduledSave(container) {
+		if (container._saveTimeout) {
+			clearTimeout(container._saveTimeout);
+			container._saveTimeout = null;
+		}
+	}
+
+	// ── Unified undo ─────────────────────────────────────────────────────────
+
+	/**
+	 * Flush any pending debounced save first (so the very latest typed state
+	 * is committed to the snapshot stack), then delegate to the canvas
+	 * UndoManager — the same path used by Ctrl+Z outside a field.
+	 */
+	static triggerUndo(container) {
+		const board = container.closest('.math-group')?.mathGroup?.board;
+		if (!board) return;
+
+		if (container._saveTimeout) {
+			clearTimeout(container._saveTimeout);
+			container._saveTimeout = null;
+			board.fileManager.saveState();
+		}
+
+		board.undoManager.undo(board);
+	}
+
+	static triggerRedo(container) {
+		const board = container.closest('.math-group')?.mathGroup?.board;
+		if (!board) return;
+
+		// Cancel any pending debounced save — a redo should not be preceded by
+		// an accidental snapshot of the partially-typed current state.
+		MathFieldEditor.cancelScheduledSave(container);
+
+		board.undoManager.redo(board);
+	}
 }
 
 export { MathFieldEditor };
+
+
+
+

--- a/assets/app/scripts/math/mathfield-editor.js
+++ b/assets/app/scripts/math/mathfield-editor.js
@@ -143,6 +143,9 @@ class MathFieldEditor {
 	}
 
 	static attachEditKeydownListener(mathFieldElement, container) {
+		if (mathFieldElement.dataset.listenersAttached === 'true') return;
+		mathFieldElement.dataset.listenersAttached = 'true';
+
 		mathFieldElement.addEventListener('keydown', (event) => {
 			const mathField = MQ(mathFieldElement);
 

--- a/assets/app/scripts/math/mathfield-event-handler.js
+++ b/assets/app/scripts/math/mathfield-event-handler.js
@@ -22,6 +22,21 @@ class MathFieldEventHandler {
 
 	handleKeyDown(event) {
 		switch (event.key) {
+			case 'Z':
+			case 'z':
+				if (event.ctrlKey || event.metaKey) {
+					if (event.shiftKey) {
+						this.handleRedoInField(event);
+					} else {
+						this.handleUndoInField(event);
+					}
+				}
+				break;
+			case 'y':
+				if (event.ctrlKey || event.metaKey) {
+					this.handleRedoInField(event);
+				}
+				break;
 			case 'Backspace':
 				this.handleBackspace(event);
 				break;
@@ -29,6 +44,18 @@ class MathFieldEventHandler {
 				this.handleEnter(event);
 				break;
 		}
+	}
+
+	handleUndoInField(event) {
+		event.preventDefault();
+		event.stopPropagation();
+		MathFieldEditor.triggerUndo(this.container);
+	}
+
+	handleRedoInField(event) {
+		event.preventDefault();
+		event.stopPropagation();
+		MathFieldEditor.triggerRedo(this.container);
 	}
 
 	handleBackspace(event) {


### PR DESCRIPTION
While using CalcLynx, I accidentally deleted a math stack containing a differential equation I spent a grueling five minutes solving. "That's no problem!" I thought to myself. Little did I know, Ctrl + Z was not a thing in CalcLynx. My heart sunk. My smile turned upside down. My day? Ruined. That one differential equation now only exists in my memory. R.I.P. Gilbert (I named him Gilbert, by the way).

I knew something had to be done. If I couldn't save my Gilbert, maybe I could add this feature once and for all, so others' Gilberts don't have to suffer the same fate. That's exactly what I did. I opened my editor, cloned CalcLynx, and started work. After hours of coding that AI definitely didn't do for me, I added the following features:

* `Ctrl + Z`: Saves your Gilbert from Death's inescapable, cold, grasp.
* `Ctrl + Shift + Z` or `Ctrl + Y`: Returns any Gilbert you just saved back to Death. I'm not sure why you would want to do this to your Gilbert, but the option's there.

Fixes #12 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added undo/redo with keyboard shortcuts (Ctrl/Cmd+Z undo, Ctrl/Cmd+Shift+Z or Ctrl/Cmd+Y redo).
  * Debounced auto-save during math editing with explicit undo/redo triggers to flush pending saves.
* **Bug Fixes**
  * Ensure undo history is seeded when loading files so the first undo restores prior content.
* **Behavior**
  * Adjusted canvas pan/drag sensitivity for more accurate pointer-to-canvas movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->